### PR TITLE
mdi:google-home was removed on Home assistant 2022.10.X

### DIFF
--- a/sdesalve_alarm/dss_xiaomi_alarm_switch_google.yaml
+++ b/sdesalve_alarm/dss_xiaomi_alarm_switch_google.yaml
@@ -2,7 +2,7 @@ homeassistant:
   customize:
     lock.ok_google_attiva_allarme:
       friendly_name: "Allarme"
-      icon_template: mdi:google-home
+      icon_template: mdi:speaker-message
         
 lock:
   ### lock per attivare/disattivare l'allarme HOME con Google Assistant


### PR DESCRIPTION
If you want to change it to this one to avoid future errors :-)